### PR TITLE
class-name binding needs spaces between classes

### DIFF
--- a/src/autocomplete.html
+++ b/src/autocomplete.html
@@ -20,7 +20,7 @@
           ref="suggestionsUL">
         <li repeat.for="suggestion of suggestions" 
             id.one-time="'au-autocomplate-' + id + '-suggestion-' + $index"
-            class-name.bind="($index === index ? 'selected' : '') + (small ? 'small' : '') + ' suggestion'"
+            class-name.bind="($index === index ? 'selected ' : '') + (small ? 'small ' : '') + 'suggestion'"
             mousedown.delegate="suggestionClicked(suggestion)"
             role="option">
           <template replaceable part="suggestion" >


### PR DESCRIPTION
the class-name binding on the suggestions was not correctly separating the class names determined by the binding expression.