### PR TITLE
allow for focus.bind

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ System.config({
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0",
     "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
     "aurelia-templating": "npm:aurelia-templating@1.4.1",
+    "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
     "npm:aurelia-binding@1.2.1": {
       "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
@@ -35,6 +36,17 @@ System.config({
     },
     "npm:aurelia-task-queue@1.2.0": {
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
+    },
+    "npm:aurelia-templating-resources@1.4.0": {
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
+      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-path": "npm:aurelia-path@1.1.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-templating@1.4.1": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",

--- a/package.json
+++ b/package.json
@@ -64,13 +64,11 @@
       "aurelia-dependency-injection": "^1.3.1",
       "aurelia-pal": "^1.3.0",
       "aurelia-task-queue": "^1.2.0",
-      "aurelia-templating": "^1.4.1"
+      "aurelia-templating": "^1.4.1",
+      "aurelia-templating-resources": "^1.4.0"
     },
     "devDependencies": {
       "aurelia-polyfills": "^1.0.0"
     }
-  },
-  "dependencies": {
-    "aurelia-templating-resources": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
     "devDependencies": {
       "aurelia-polyfills": "^1.0.0"
     }
+  },
+  "dependencies": {
+    "aurelia-templating-resources": "^1.4.0"
   }
 }


### PR DESCRIPTION
The standard Aurelia focus custom attribute now works with the autocomplete custom element.

```
<autocomplete focus.bind="xxxx" value.bind=............</autocomplete>
```