### PR TITLE
fix(styles): replace class-name.bind with class.bind

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ System.config({
     "aurelia-pal": "npm:aurelia-pal@1.3.0",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0",
     "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
-    "aurelia-templating": "npm:aurelia-templating@1.4.1",
+    "aurelia-templating": "npm:aurelia-templating@1.4.2",
     "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
     "npm:aurelia-binding@1.2.1": {
       "aurelia-logging": "npm:aurelia-logging@1.3.1",
@@ -46,9 +46,9 @@ System.config({
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.4.1"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
-    "npm:aurelia-templating@1.4.1": {
+    "npm:aurelia-templating@1.4.2": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       "aurelia-dependency-injection": "^1.3.1",
       "aurelia-pal": "^1.3.0",
       "aurelia-task-queue": "^1.2.0",
-      "aurelia-templating": "^1.4.1",
+      "aurelia-templating": "^1.4.2",
       "aurelia-templating-resources": "^1.4.0"
     },
     "devDependencies": {

--- a/src/autocomplete.html
+++ b/src/autocomplete.html
@@ -1,6 +1,6 @@
 <template>
   <require from="./autocomplete.css"></require>
-  <div class-name.bind="'form-group ' + (small ? 'form-group-sm' : '')">
+  <div class.bind="'form-group ' + (small ? 'form-group-sm' : '')">
 		<label if.bind="title.length > 0"
            for="${'au-autocomplete-' + id}"
            class="control-label">${title}</label>
@@ -20,7 +20,7 @@
           ref="suggestionsUL">
         <li repeat.for="suggestion of suggestions" 
             id.one-time="'au-autocomplate-' + id + '-suggestion-' + $index"
-            class-name.bind="($index === index ? 'selected ' : '') + (small ? 'small ' : '') + 'suggestion'"
+            class.bind="($index === index ? 'selected ' : '') + (small ? 'small ' : '') + 'suggestion'"
             mousedown.delegate="suggestionClicked(suggestion)"
             role="option">
           <template replaceable part="suggestion" >


### PR DESCRIPTION
`class-name.bind` replaces any existing classes specified on the element. This causes a problem with validation as in certain cases the `has-error` class is removed. This replaces `class-name.bind` with `class.bind`.